### PR TITLE
fix typo in generate_data_new.ipynb when filtering icd50

### DIFF
--- a/preprocess/generate_data_new.ipynb
+++ b/preprocess/generate_data_new.ipynb
@@ -223,7 +223,7 @@
     "        subject_id = str(int(key[0]))\n",
     "        hadm_id = str(int(key[1]))\n",
     "        icd = \";\".join([str(c) for c in icd_dict[key]])\n",
-    "        if base_name == \"mimic-50\":\n",
+    "        if base_name == \"mimic3-50\":\n",
     "            filtered_codes = set(icd_dict[key]).intersection(set(codes_50))\n",
     "            if len(filtered_codes) > 0:\n",
     "                icd = \";\".join([str(c) for c in filtered_codes])\n",


### PR DESCRIPTION
I think there was a small typo when filtering the ICD50 labels: from `mimic-50` to `mimic3-50`. This typo causes the filtering process to be skipped.